### PR TITLE
Capture GCS exception when uploading a file

### DIFF
--- a/cloud_storage_client/exceptions.py
+++ b/cloud_storage_client/exceptions.py
@@ -1,6 +1,9 @@
-
-
 class IncorrectCredentialsException(Exception):
     def __init__(self, code, *args, **kwargs):
         self.id = code
         Exception.__init__(self, *args, **kwargs)
+
+
+class NotFoundException(Exception):
+    def __init__(self, code, *args, **kwargs):
+        self.id = 404

--- a/cloud_storage_client/storage.py
+++ b/cloud_storage_client/storage.py
@@ -8,7 +8,7 @@ from cloud_storage_client import ftp
 from cloud_storage_client import file_system
 import time
 
-from cloud_storage_client.exceptions import IncorrectCredentialsException
+from cloud_storage_client.exceptions import IncorrectCredentialsException, NotFoundException
 
 GOOGLE_CLOUD_STORAGE = 'GCS'
 AMAZON_S3 = 'S3'
@@ -117,8 +117,10 @@ class StorageClient(storage_adapter.StorageAdapter):
                 self._upload_file(src_file, dst_file)
             except IncorrectCredentialsException as e:
                 raise e
+            except NotFoundException as e:
+                raise e
             except:
-                print('Retriying request in', seconds_wait, ' seconds', ValueError)
+                print('Retriying request in', seconds_wait, ' seconds')
                 time.sleep(seconds_wait)
                 retries_count = retries_count + 1
                 seconds_wait = seconds_wait * self.backoffValue

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,24 @@
 import os
 from setuptools import setup
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
     name = "cloud_storage_client",
-    version = "1.0.2",
+    version = "1.0.3",
     author = "Pablo Aguirre",
     author_email = "paguirrerubio@gmail.com",
     license = "MIT",
-    url = "http://pypi.org/project/google-cloud-storage/",
+    url = "https://pypi.org/project/cloud-storage-client/",
     packages=['cloud_storage_client'],
     long_description=read('README.md'),
     long_description_content_type="text/markdown",
     install_requires=[
         'botocore==1.11.4',
         'boto3==1.8.4',
-        'google.cloud==0.32.0',
+        'google-cloud-storage==1.18.0',
         'azure==3.0.0',
         'pysftp==0.2.9'
     ],


### PR DESCRIPTION
- Capture the exception when the upload is not able to find the bucket
- Updated google dependencies
- Updated version
- Updated url

The google dependencies have been updated as they were deprecated a year ago

> WARNING: The google-cloud Python package is deprecated. On June 18, 2018, this package will no longer install any other packages. Please install the product-specific google-cloud-* packages needed for your application.

Any issues found while testing but it is a big change, so we have to keep an eye on it

The url was updated to https://pypi.org/project/cloud-storage-client/ to point the correct place