### PR TITLE
Check the starting character of path to normalize it

### DIFF
--- a/cloud_storage_client/as3.py
+++ b/cloud_storage_client/as3.py
@@ -32,6 +32,8 @@ class AS3Client:
     def delete_file(self, file_path):
         try:
             bucket = self.resource.Bucket(self.bucket_name)
+            if file_path[0] == '/':
+                file_path = file_path[1:len(file_path)]
             for obj in bucket.objects.filter(Prefix=file_path):
                 obj.delete()
         except ClientError as e:


### PR DESCRIPTION
When deleting a file in s3 storage, if the path starts with / the file is not found so it can not be deleted. There is no exception thrown in this case, so the consumer of this library does not realise whether the file has been successfully deleted or not