### PR TITLE
Uploading folder to ftp issue

### DIFF
--- a/cloud_storage_client/ftp.py
+++ b/cloud_storage_client/ftp.py
@@ -133,13 +133,7 @@ class FTPClient():
     file.close()
 
   def upload_folder(self, dst_folder, src_folder, do_tar=False, do_compress=False):
-
-    if dst_folder[0] == '/':
-      dst_folder = dst_folder[1:len(dst_folder)]
-    if dst_folder[-1] == '/':
-      dst_folder = dst_folder[0:len(dst_folder) - 1]
-    dst_folder = dst_folder.replace('//', '/')
-
+    dst_folder = dst_folder.strip('/')
     split_dst_file = dst_folder.split('/')
     try:
       self.client.cwd(dst_folder)

--- a/cloud_storage_client/ftp.py
+++ b/cloud_storage_client/ftp.py
@@ -133,20 +133,18 @@ class FTPClient():
     file.close()
 
   def upload_folder(self, dst_folder, src_folder, do_tar=False, do_compress=False):
-    if dst_folder[0] != '/':
-      remote_folder = '/' + dst_folder
-    else:
-      remote_folder = dst_folder
 
-    split_dst_file = remote_folder.split('/')
-    remote_path = ""
-    for i in range(len(split_dst_file) - 1):
-      remote_path += "/" + split_dst_file[i]
+    if dst_folder[0] == '/':
+      dst_folder = dst_folder[1:len(dst_folder)]
+    if dst_folder[-1] == '/':
+      dst_folder = dst_folder[0:len(dst_folder) - 1]
+    dst_folder = dst_folder.replace('//', '/')
 
+    split_dst_file = dst_folder.split('/')
     try:
-      self.client.cwd(remote_path)
+      self.client.cwd(dst_folder)
     except:
-      for i in range(len(split_dst_file) - 1):
+      for i in range(len(split_dst_file)):
         try:
           self.client.cwd(split_dst_file[i])
         except:


### PR DESCRIPTION
When uploading a folder to ftp, if the path does not end with /, the files gets uploaded in the parent directory to the one we wanted to upload. This does not happen if the path ends with 0. Now there is a normalization of the destination path to avoid this issue